### PR TITLE
Fix PyScript links

### DIFF
--- a/web/simulation_pyscript.html
+++ b/web/simulation_pyscript.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Financial Simulator - PyScript</title>
-    <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
-    <script defer src="https://pyscript.net/latest/pyscript.js"></script>
+    <link rel="stylesheet" href="https://pyscript.net/releases/2025.5.1/core.css" />
+    <script type="module" src="https://pyscript.net/releases/2025.5.1/core.js"></script>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .input-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(250px,1fr)); gap: 10px; }


### PR DESCRIPTION
## Summary
- fix CDN URLs for PyScript in simulation_pyscript.html

## Testing
- `python -m py_compile simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_684b5ccd067083308cc745b85e3ad009